### PR TITLE
Actually the use zabbix_nginx_vhost_[tls_]port variables in the nginx…

### DIFF
--- a/roles/zabbix_web/templates/nginx_vhost.conf.j2
+++ b/roles/zabbix_web/templates/nginx_vhost.conf.j2
@@ -2,7 +2,7 @@
 
 server {
 {% if not zabbix_nginx_tls %}
-    listen 80;
+    listen {{ zabbix_nginx_vhost_port }};
 {% else %}
 {% if zabbix_letsencrypt %}
     server_tokens off;
@@ -19,7 +19,7 @@ server {
 
 server {
 {% endif %}
-    listen 443 ssl;
+    listen {{ zabbix_nginx_vhost_tls_port }} ssl;
 {% if zabbix_letsencrypt and zabbix_letsencrypt_cert.stat.exists %}
     ssl_certificate /etc/letsencrypt/live/{{ zabbix_websrv_servername }}/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/{{ zabbix_websrv_servername }}/privkey.pem;


### PR DESCRIPTION
… config

According to the documentation at https://github.com/ansible-collections/community.zabbix/tree/main/roles/zabbix_web, zabbix_nginx_vhost_port and zabbix_nginx_vhost_tls_port control the port nginx uses.  However, these weren't actually references in the nginx config.